### PR TITLE
Add quotes to handle dSYM folder path with spaces

### DIFF
--- a/xcode_build_dsym_upload.sh
+++ b/xcode_build_dsym_upload.sh
@@ -145,7 +145,7 @@ fi
 DSYM_UPLOAD_URL="${ADRUM_EUM_PROCESSOR}/v2/account/${ADRUM_ACCOUNT_NAME}/ios-dsym"
 
 # Find all dsym files
-find ${DWARF_DSYM_FOLDER_PATH} -type d -name \*.dSYM -print |
+find "${DWARF_DSYM_FOLDER_PATH}" -type d -name \*.dSYM -print |
     while read dsym; do
         DSYM_UUID=$(dsymIDForUploading "${dsym}")
         if [[ $DSYM_UUID == '' ]]; then


### PR DESCRIPTION
Issue can be reproduced in bash when `DWARF_DSYM_FOLDER_PATH` contains whitespace. This results in errors for the find command, e.g. if equal to `/Users/user/my dsyms folder` :

```
find: /Users/user/my: No such file or directory
find: dsyms: No such file or directory
find: folder: No such file or directory
```

Adding quotes fixes the issue.